### PR TITLE
Template: Enumerator::ArithmeticSequence support for length

### DIFF
--- a/lib/ronin/fuzzing/core_ext/string.rb
+++ b/lib/ronin/fuzzing/core_ext/string.rb
@@ -31,7 +31,7 @@ class String
   #
   # Generate permutations of Strings from a format template.
   #
-  # @param [Array(<String,Symbol,Enumerable>, <Integer,Array,Range>)] fields
+  # @param [Array(<String,Symbol,Enumerable>, <Integer,Array,Range,Enumerator::ArithmeticSequence>)] fields
   #   The fields which defines the string or character sets which will
   #   make up parts of the String.
   #

--- a/lib/ronin/fuzzing/template.rb
+++ b/lib/ronin/fuzzing/template.rb
@@ -72,7 +72,7 @@ module Ronin
           case length
           when Integer
             length.times { @enumerators << enum.dup }
-          when Array, Range
+          when Array, Range, Enumerator::ArithmeticSequence
             @enumerators << Combinatorics::Generator.new do |g|
               length.each do |sublength|
                 superset = Array.new(sublength) { enum.dup }
@@ -83,7 +83,7 @@ module Ronin
           when nil
             @enumerators << enum
           else
-            raise(TypeError,"length must be an Integer, Range or Array")
+            raise(TypeError,"length must be an Integer, Range, Array or Enumerator::ArithmeticSequence")
           end
         end
       end


### PR DESCRIPTION
This example is on the documentation but currently doesn't work

https://github.com/noraj/ronin-fuzzer/blob/e398afb5020eb37c6b94db1b1e1b5ff2a8921a07/lib/ronin/fuzzing/core_ext/string.rb#L81-L84

```plaintext
irb(main):067:1* String.generate(['/AA', (1..100).step(5)]) do |path|
irb(main):068:1*   puts path
irb(main):069:0> end
/home/noraj/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/ronin-fuzzer-0.1.0/lib/ronin/fuzzing/template.rb:86:in `block in initialize': length must be an Integer, Range or Array (TypeError)

            raise(TypeError,"length must be an Integer, Range or Array")
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        from /home/noraj/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/ronin-fuzzer-0.1.0/lib/ronin/fuzzing/template.rb:54:in `each'
        from /home/noraj/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/ronin-fuzzer-0.1.0/lib/ronin/fuzzing/template.rb:54:in `initialize'
        from /home/noraj/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/ronin-fuzzer-0.1.0/lib/ronin/fuzzing/core_ext/string.rb:89:in `new'
        from /home/noraj/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/ronin-fuzzer-0.1.0/lib/ronin/fuzzing/core_ext/string.rb:89:in `generate'
        from (irb):67:in `<main>'
        from /home/noraj/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
        from /home/noraj/.asdf/installs/ruby/3.2.2/bin/irb:25:in `load'
        from /home/noraj/.asdf/installs/ruby/3.2.2/bin/irb:25:in `<main>'
irb(main):070:0> (1..100).step(5).class
=> Enumerator::ArithmeticSequence
irb(main):071:0> (1..100).class
=> Range
```